### PR TITLE
build process refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,4 @@
 node_modules
 .DS_Store
 .env
-
-/js/
-/views/
-/css/
-/fonts/
+dist/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,6 +126,14 @@ gulp.task('css-vendors', function () {
     .pipe(gulp.dest(vendorDest));
 });
 
+// compress and combine svg icons
+gulp.task('svg', function () {
+  return gulp.src('./img/icons/*.svg')
+    .pipe($.svgmin())
+    .pipe($.svgstore())
+    .pipe(gulp.dest('./img/icons'));
+});
+
 // Watch Files For Changes
 gulp.task('watch', function() {
   gulp.watch(jsFiles, ['scripts']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,159 +1,191 @@
-// Settings
+// Proxy URL (optional)
+var siteUrl = '*.dev';
 
-var siteUrl = 'crown.dev';
-
+// reference to the main scss file
 var coreScss = 'src/scss/app.scss';
 
-var jsFiles    = [
-    'src/components/**/*.factory.js',
-    'src/components/**/*.directive.js',
-    'src/components/**/*.service.js',
-    'src/js/*.js',
-    'src/views/**/*.js'
-];
-var scssFiles  = ['src/**/*.scss'];
-var viewFiles  = ['src/views/**/*.html', 'src/components/**/*.html'];
-var fontFiles  = []; // add font files here
+// project files
+var jsFiles   = ['src/**/*.js'];
+var scssFiles = ['src/**/*.scss'];
+var htmlFiles = ['src/**/*.html'];
+var fontFiles = []; // add font files here
 
-var jsVendors  = [
-    'node_modules/angular/angular.js',
-    'node_modules/angular-ui-router/release/angular-ui-router.js',
-    'node_modules/angular-resource/angular-resource.js'
+// vendor files
+var jsVendors = [
+  'node_modules/angular/angular.js',
+  'node_modules/angular-ui-router/release/angular-ui-router.js',
+  'node_modules/angular-resource/angular-resource.js'
 ];
-var cssVendors = [
-    'node_modules/normalize-sass/normalize'
-];
+var cssVendors = [];
 
+// distribution directories
+var jsDest     = './dist/js';
+var cssDest    = './dist/css';
+var htmlDest   = './dist/html';
+var fontDest   = './dist/fonts';
+var vendorDest = './dist/vendors';
 
-// Assign Gulp
+// plugins
 var gulp        = require('gulp'),
     browserSync = require('browser-sync').create(),
-    jasmine     = require('gulp-jasmine'),
     reporters   = require('jasmine-reporters'),
     karma       = require('karma').server;
 
-// Plugins
+// set up gulp-specific plugins
 $ = require('gulp-load-plugins')({
-    pattern: [
-        'gulp-*'
-    ]
+  pattern: [
+    'gulp-*'
+  ]
 });
 
-/*
- *
- *  Gulp Logic
- *
- */
+/****************************************
+  Gulp logic
+*****************************************/
 
 // browser-sync task for starting the server by proxying a local url
-gulp.task('browser-sync', function() {
-    browserSync.init({
-        proxy: siteUrl
-    });
+gulp.task('browser-sync-proxy', function() {
+  browserSync.init({
+    proxy: siteUrl
+  });
 });
 
-// launch browser sync as a server without a local url
-gulp.task('browser-sync-server', function () {
-    browserSync.init({
-        server: {
-            baseDir: './'
-        }
-    });
+// launch browser sync as a standalone server
+gulp.task('browser-sync-standalone', function () {
+  browserSync.init({
+    server: {
+      baseDir: './'
+    }
+  });
 });
 
 // Lint Javascript Task
 gulp.task('lint', function() {
-    return gulp.src(jsFiles)
-        .pipe($.jshint())
-        .pipe($.jshint.reporter('jshint-stylish'));
-});
-
-// compile, prefix, and minify the sass
-gulp.task('styles', function() {
-    return gulp.src(coreScss)
-        .pipe($.sourcemaps.init())
-        .pipe($.sass().on('error', $.sass.logError))
-        .pipe($.autoprefixer(["> 1%", "last 2 versions"], { cascade: true }))
-        .pipe(gulp.dest('./css'))
-        .pipe($.rename({suffix: '.min'}))
-        .pipe($.cleanCss())
-        .pipe($.sourcemaps.write('.'))
-        .pipe(gulp.dest('./css'))
-        .pipe(browserSync.stream());
+  return gulp.src(jsFiles)
+    .pipe($.jshint({esversion: 6}))
+    .pipe($.jshint.reporter('jshint-stylish'));
 });
 
 // Concatenate & Minify JS
 gulp.task('scripts', ['lint'], function() {
-    return gulp.src(jsFiles)
-        .pipe($.plumber())
-        .pipe($.ngAnnotate())
-        .pipe($.sourcemaps.init())
-        .pipe($.concat('app.js'))
-        .pipe(gulp.dest('./js'))
-        .pipe($.rename({suffix: '.min'}))
-        .pipe($.uglify())
-        .pipe($.sourcemaps.write('.'))
-        .pipe(gulp.dest('./js'))
-        .pipe(browserSync.stream());
+  return gulp.src(jsFiles)
+  .pipe($.plumber())
+  .pipe($.ngAnnotate())
+  .pipe($.sourcemaps.init())
+    .pipe($.concat('app.js'))
+    .pipe($.babel({
+      presets: ['es2015']
+    }))
+    .pipe(gulp.dest(jsDest))
+    .pipe($.rename({suffix: '.min'}))
+    .pipe($.uglify())
+  .pipe($.sourcemaps.write('.'))
+  .pipe(gulp.dest(jsDest))
+  .pipe(browserSync.stream());
+});
+
+// compile, prefix, and minify the sass
+gulp.task('styles', function() {
+  return gulp.src(coreScss)
+    .pipe($.sourcemaps.init())
+      .pipe($.sass().on('error', $.sass.logError))
+      .pipe($.autoprefixer(["> 1%", "last 2 versions"], { cascade: true }))
+      .pipe(gulp.dest(cssDest))
+      .pipe($.rename({suffix: '.min'}))
+      .pipe($.cleanCss())
+    .pipe($.sourcemaps.write('.'))
+    .pipe(gulp.dest(cssDest))
+    .pipe(browserSync.stream());
 });
 
 // Concatenate and Minify Vendor JS
 gulp.task('js-vendors', function() {
-    return gulp.src(jsVendors)
-        .pipe($.plumber())
-        .pipe($.concat('vendors.min.js'))
-        .pipe($.uglify())
-        .pipe(gulp.dest('./js'));
+  return gulp.src(jsVendors)
+    .pipe($.plumber())
+    .pipe($.concat('vendors.min.js'))
+    .pipe($.uglify())
+    .pipe(gulp.dest(vendorDest));
 });
 
 // copy fonts
 gulp.task('fonts', function() {
-    gulp.src(fontFiles)
-        .pipe(gulp.dest('./fonts'));
+  gulp.src(fontFiles)
+    .pipe(gulp.dest(fontDest));
 });
 
 // copy views
 gulp.task('views', function() {
-    gulp.src(viewFiles)
-        .pipe($.htmlmin({collapseWhitespace: true}))
-        .pipe(gulp.dest('./views'));
+  gulp.src(htmlFiles)
+    .pipe($.htmlmin({collapseWhitespace: true}))
+    .pipe($.rename({dirname: '/', suffix: '.min'}))
+    .pipe(gulp.dest(htmlDest));
 });
 
 // copy vendor CSS
 gulp.task('css-vendors', function () {
-    return gulp.src(cssVendors)
-        .pipe(gulp.dest('.'));
+  return gulp.src(cssVendors)
+    .pipe(gulp.dest(vendorDest));
 });
 
 // Watch Files For Changes
 gulp.task('watch', function() {
-    gulp.watch(jsFiles, ['scripts']);
-    gulp.watch(scssFiles, ['styles']);
-    gulp.watch(viewFiles, ['views']);
+  gulp.watch(jsFiles, ['scripts']);
+  gulp.watch(scssFiles, ['styles']);
+  gulp.watch(htmlFiles, ['views']);
+  gulp.watch('**/*.html', browserSync.reload);
 });
 
 // Unit testing
 gulp.task('tests', function(done) {
-
-    karma.start({
-        configFile: __dirname + '/karma.conf.js'
-    }, done);
-
+  karma.start({
+    configFile: __dirname + '/karma.conf.js'
+  }, done);
 });
 
+/****************************************
+  Gulp Tasks
+*****************************************/
 
+// default task builds everything, opens up a proxy server, and watches for changes
+gulp.task('default', [
+  'styles',
+  'scripts',
+  'fonts',
+  'views',
+  'browser-sync-proxy',
+  'watch'
+]);
 
+// local task builds everything, opens up a standalone server, and watches for changes
+gulp.task('local', [
+  'styles',
+  'scripts',
+  'fonts',
+  'views',
+  'browser-sync-standalone',
+  'watch'
+]);
 
+// builds everything
+gulp.task('build', [
+  'styles',
+  'scripts',
+  'fonts',
+  'views',
+  'css-vendors',
+  'js-vendors'
+]);
 
+// builds the vendor files
+gulp.task('vendors', [
+  'css-vendors',
+  'js-vendors'
+]);
 
+// run the tests and watch for changes
+gulp.task('test', [
+  'tests',
+  'watch'
+]);
 
-
-
-
-// task chains
-gulp.task('default', ['styles', 'fonts', 'views', 'css-vendors', 'js-vendors', 'scripts', 'watch']); // build app
-gulp.task('serve', ['styles', 'scripts', 'fonts', 'views', 'browser-sync-server', 'watch']); // launch server
-gulp.task('build', ['styles', 'scripts', 'fonts', 'views', 'browser-sync', 'watch']); // proxy
-gulp.task('vendors', ['css-vendors', 'js-vendors']); // vendor js and css
-gulp.task('test', ['tests', 'watch']);
+// run the tests once
 gulp.task('test-once', ['tests']);

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
     <meta property="fb:admins" content="Facebook numberic ID" />
 
     <!-- Stylesheets -->
-    <link rel="stylesheet" href="css/style.min.css" />
+    <link rel="stylesheet" href="dist/css/app.min.css" />
 
 </head>
 <body>
@@ -62,8 +62,8 @@
     </div>
 
     <!-- Scripts -->
-    <script src="js/vendors.min.js"></script>
-    <script src="js/app.min.js"></script>
+    <script src="dist/vendors/vendors.min.js"></script>
+    <script src="dist/js/app.min.js"></script>
     <script type="text/javascript">
         angular.bootstrap(document.body, ['myApp']);
     </script>

--- a/package.json
+++ b/package.json
@@ -12,11 +12,14 @@
     "angular-ui-router": "^0.3.1"
   },
   "devDependencies": {
+    "angular-mocks": "^1.5.8",
+    "babel-preset-es2015": "^6.14.0",
     "bourbon": "^4.2.7",
     "bourbon-neat": "^1.8.0",
     "browser-sync": "^2.13.0",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
+    "gulp-babel": "^6.1.2",
     "gulp-clean-css": "^2.0.11",
     "gulp-concat": "^2.6.0",
     "gulp-filter": "^4.0.0",
@@ -36,16 +39,14 @@
     "jasmine-reporters": "^2.2.0",
     "jshint": "^2.9.2",
     "jshint-stylish": "^2.2.0",
-    "normalize-sass": "^1.0.0",
-    "angular-mocks":"^1.5.8",
-    "karma":"^1.1.2",
-    "karma-chrome-launcher":"^1.0.1",
-    "karma-firefox-launcher":"^1.0.0",
-    "karma-jasmine":"^1.0.2",
-    "karma-junit-reporter":"^1.1.0",
-    "karma-phantomjs-launcher":"^1.0.1",
-    "phantomjs":"^2.1.7"
-
+    "karma": "^1.1.2",
+    "karma-chrome-launcher": "^1.0.1",
+    "karma-firefox-launcher": "^1.0.0",
+    "karma-jasmine": "^1.0.2",
+    "karma-junit-reporter": "^1.1.0",
+    "karma-phantomjs-launcher": "^1.0.1",
+    "normalize.css": "^4.2.0",
+    "phantomjs": "^2.1.7"
   },
   "scripts": {
     "test": "gulp test"

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -1,3 +1,8 @@
-function getView (view){
-    return 'views/'+view+'/'+view+'.html';
+/**
+ * Retrieve the string URL of a view or directive template
+ * @param  {string} filename Name of the html file to retrieve
+ * @return {string}          Relative URL to the minified template
+ */
+function getView (filename){
+  return `dist/html/${filename}.min.html`;
 }

--- a/src/js/helpers.js
+++ b/src/js/helpers.js
@@ -1,8 +1,10 @@
 /**
+ * @name getTemplateUrl
+ * @description
  * Retrieve the string URL of a view or directive template
  * @param  {string} filename Name of the html file to retrieve
  * @return {string}          Relative URL to the minified template
  */
-function getView (filename){
+function getTemplateUrl (filename){
   return `dist/html/${filename}.min.html`;
 }

--- a/src/scss/app.scss
+++ b/src/scss/app.scss
@@ -1,5 +1,17 @@
-@import '../../node_modules/bourbon/app/assets/stylesheets/bourbon';
-@import '../../node_modules/bourbon-neat/app/assets/stylesheets/neat';
+/**
+*    ___   ___    _  _  ___ _____   __  __  ___  ___ ___ _____   __
+*   |   \ / _ \  | \| |/ _ \_   _| |  \/  |/ _ \|   \_ _| __\ \ / /
+*   | |) | (_) | | .` | (_) || |   | |\/| | (_) | |) | || _| \ V /
+*   |___/ \___/  |_|\_|\___/ |_|   |_|  |_|\___/|___/___|_|   |_|
+* This file is generated with SASS and will be overwritten
+*/
+
+// bourbonize it
+@import "../../node_modules/bourbon/app/assets/stylesheets/bourbon";
+@import "../../node_modules/bourbon-neat/app/assets/stylesheets/neat";
+
+// normalize it
+@import "../../node_modules/normalize.css/normalize";
 
 @import "functions";
 @import "mixins";

--- a/src/views/home/home.js
+++ b/src/views/home/home.js
@@ -21,7 +21,7 @@
                 url: '/',
                 views: {
                     'main@': {
-                        templateUrl: getView('home', true),
+                        templateUrl: getTemplateUrl('home'),
                         controller: HomeCtrl,
                         controllerAs: 'home'
                     }


### PR DESCRIPTION
Pretty major overhaul of the gulp build process. I'm proposing a lot of changes and I've commented on some of them for further discussion.

* The key addition is babel to transpile es2015.
* A key change is to drop all built assets into `./dist` subdirectories.
* A key change is to drop normalize sass port and just utilize the core normalize package.